### PR TITLE
Improve window average

### DIFF
--- a/processes/process_windows_average/process_windows_average_time.m
+++ b/processes/process_windows_average/process_windows_average_time.m
@@ -19,7 +19,7 @@ function varargout = process_windows_average_time( varargin )
 % For more information type "brainstorm license" at command prompt.
 % =============================================================================@
 %
-% Authors: Edouard Delaire, 2018
+% Authors: Edouard Delaire, 2018, 2025
 
 eval(macro_method);
 end
@@ -88,7 +88,20 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
         elseif strcmp(sInputs(1).FileType, 'results') 
             unique_dataFile = unique({sInputs.DataFile});
             if length(unique_dataFile) > 1
-                % todo
+
+                for iDataFile = 1:length(unique_dataFile)
+                    iFile  = find( strcmp( {sInputs.DataFile} , unique_dataFile{iDataFile}));
+                    OutputFile  =     bst_process('CallProcess', 'process_windows_average_time',   {sInputs(iFile).FileName},    [], ...
+                                                                                                    'Eventname',      sProcess.options.Eventname.Value, ...
+                                                                                                    'timewindow',     sProcess.options.timewindow.Value{1} , ...
+                                                                                                    'remove_DC',      sProcess.options.remove_DC.Value, ...
+                                                                                                    'baselinewindow', sProcess.options.baselinewindow.Value{1} );
+                    for iOutput = 1:length(OutputFile)
+                        OutputFiles{end+1} = OutputFile(iOutput).FileName;
+                    end
+                end
+                
+                return;
             else
 
                 new_dataFIle =     bst_process('CallProcess', 'process_windows_average_time',   unique_dataFile,    [], ...
@@ -217,7 +230,7 @@ function [sDataIn, sInputIn] = load_input_data(sProcess, sInputs)
         sInputIn = struct('A', sDataIn.F, 'TimeVector', sDataIn.Time,  'events', sDataIn.Events); 
         
     elseif strcmp(sInputs.FileType, 'results') 
-        sDataIn = in_bst_results(sInputs.FileName);
+        sDataIn = in_bst_results(sInputs.FileName, 1);
         sData = in_bst_data(sInputs.DataFile,'Events');
         
         

--- a/processes/process_windows_average/process_windows_average_time.m
+++ b/processes/process_windows_average/process_windows_average_time.m
@@ -26,7 +26,7 @@ end
 
 
 %% ===== GET DESCRIPTION =====
-function sProcess = GetDescription() %#ok<DEFNU>
+function sProcess = GetDescription()
     % Description the process
     sProcess.Comment     = 'Windows Average';
     sProcess.FileTag     = 'WAvg';
@@ -79,15 +79,14 @@ end
 
 
 %% ===== FORMAT COMMENT =====
-function Comment = FormatComment(sProcess) %#ok<DEFNU>
+function Comment = FormatComment(sProcess)
     % Get time window
     Comment = [sProcess.Comment, ': [', process_extract_time('GetTimeString', sProcess), ']'];
 end
 
 
 %% ===== RUN =====
-function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
-     OutputFiles= {};
+function OutputFiles = Run(sProcess, sInputs) 
 
 
     % First handle all the case, where we have multiple files, or results
@@ -95,7 +94,9 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
     % be able to still have a datafile supervising the results in the
     % database. 
 
+    OutputFiles= {};
     if length(sInputs) > 1
+
         if strcmp(sInputs(1).FileType, 'data') 
 
             for iFile = 1:length(sInputs)
@@ -107,9 +108,14 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                                                                                                 'filter_trials',   sProcess.options.filter_trials.Value, ...
                                                                                                 'trials_info',     sProcess.options.trials_info.Value);
             end
+            
+            return;
+        end
 
-        elseif strcmp(sInputs(1).FileType, 'results') 
+        if strcmp(sInputs(1).FileType, 'results') 
             unique_dataFile = unique({sInputs.DataFile});
+
+
             if length(unique_dataFile) > 1
 
                 for iDataFile = 1:length(unique_dataFile)
@@ -127,40 +133,38 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                 end
 
                 return;
-            else
-
-                new_dataFIle =     bst_process('CallProcess', 'process_windows_average_time',   unique_dataFile,    [], ...
-                                                                                                'Eventname',      sProcess.options.Eventname.Value, ...
-                                                                                                'timewindow',     sProcess.options.timewindow.Value{1} , ...
-                                                                                                'remove_DC',      sProcess.options.remove_DC.Value, ...
-                                                                                                'baselinewindow', sProcess.options.baselinewindow.Value{1}, ...
-                                                                                                'filter_trials',   sProcess.options.filter_trials.Value, ...
-                                                                                                'trials_info',     sProcess.options.trials_info.Value);
-
-                for iFile = 1:length(sInputs)
-                    OutputFile  =     bst_process('CallProcess', 'process_windows_average_time', {sInputs(iFile).FileName},    [], ...
-                                                                                    'Eventname',      sProcess.options.Eventname.Value, ...
-                                                                                    'timewindow',     sProcess.options.timewindow.Value{1} , ...
-                                                                                    'remove_DC',      sProcess.options.remove_DC.Value, ...
-                                                                                    'baselinewindow', sProcess.options.baselinewindow.Value{1}, ...
-                                                                                    'filter_trials',  sProcess.options.filter_trials.Value, ...
-                                                                                    'trials_info',    sProcess.options.trials_info.Value, ...
-                                                                                    'new_dataFIle',   new_dataFIle.FileName );
-
-                    OutputFiles{end+1} = OutputFile.FileName;
-                end
-
             end
-        else
-            OutputFiles = {};
+            
+            new_dataFIle =  bst_process('CallProcess', 'process_windows_average_time',   unique_dataFile,    [], ...
+                                                                                            'Eventname',      sProcess.options.Eventname.Value, ...
+                                                                                            'timewindow',     sProcess.options.timewindow.Value{1} , ...
+                                                                                            'remove_DC',      sProcess.options.remove_DC.Value, ...
+                                                                                            'baselinewindow', sProcess.options.baselinewindow.Value{1}, ...
+                                                                                            'filter_trials',   sProcess.options.filter_trials.Value, ...
+                                                                                            'trials_info',     sProcess.options.trials_info.Value);
+
+            for iFile = 1:length(sInputs)
+                OutputFile  =  bst_process('CallProcess', 'process_windows_average_time', {sInputs(iFile).FileName},    [], ...
+                                                                                'Eventname',      sProcess.options.Eventname.Value, ...
+                                                                                'timewindow',     sProcess.options.timewindow.Value{1} , ...
+                                                                                'remove_DC',      sProcess.options.remove_DC.Value, ...
+                                                                                'baselinewindow', sProcess.options.baselinewindow.Value{1}, ...
+                                                                                'filter_trials',  sProcess.options.filter_trials.Value, ...
+                                                                                'trials_info',    sProcess.options.trials_info.Value, ...
+                                                                                'new_dataFIle',   new_dataFIle.FileName );
+
+                OutputFiles{end+1} = OutputFile.FileName;
+            end
+            
+            return;
         end
 
+        OutputFiles = {};
         return;
     end
 
 
     % We finaly do the average on a specific file here. 
-
     OutputFiles  = {};
 
 
@@ -271,14 +275,8 @@ function [sDataIn, sInputIn] = load_input_data(sProcess, sInputs)
         if isfield(sProcess.options, 'new_dataFIle') && ~isempty(sProcess.options.new_dataFIle)
             sDataIn.DataFile = sProcess.options.new_dataFIle.Value;
         else
-            
-            new_dataFIle =     bst_process('CallProcess', 'process_windows_average_time', {sInputs.DataFile},    [], ...
-                'Eventname',      sProcess.options.Eventname.Value, ...
-                'timewindow',     sProcess.options.timewindow.Value{1} , ...
-                'remove_DC',      sProcess.options.remove_DC.Value, ...
-                'baselinewindow', sProcess.options.baselinewindow.Value{1}, ...
-                'overwrite',      0);
-            sDataIn.DataFile =   new_dataFIle.FileName;
+            sDataIn.DataFile = [];
+            warning('No new data file found')
         end
         
         

--- a/processes/process_windows_average/process_windows_average_time.m
+++ b/processes/process_windows_average/process_windows_average_time.m
@@ -80,14 +80,7 @@ end
 
 %% ===== RUN =====
 function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
-      
-    options = struct('timewindow',      sProcess.options.timewindow.Value{1}, ...
-                     'remove_DC',       sProcess.options.remove_DC.Value,...
-                     'baselinewindow',  sProcess.options.baselinewindow.Value{1}, ...
-                     'Eventname',       sProcess.options.Eventname.Value);
-    
-    OutputFiles  = {};
-
+     
     if length(sInputs) > 1
         if strcmp(sInputs(1).FileType, 'data') 
 
@@ -96,8 +89,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                                                                                                 'Eventname',      sProcess.options.Eventname.Value, ...
                                                                                                 'timewindow',     sProcess.options.timewindow.Value{1} , ...
                                                                                                 'remove_DC',      sProcess.options.remove_DC.Value, ...
-                                                                                                'baselinewindow', sProcess.options.baselinewindow.Value{1}, ...
-                                                                                                'overwrite',      0);
+                                                                                                'baselinewindow', sProcess.options.baselinewindow.Value{1});
             end
 
         elseif strcmp(sInputs(1).FileType, 'results') 
@@ -110,8 +102,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                                                                                                 'Eventname',      sProcess.options.Eventname.Value, ...
                                                                                                 'timewindow',     sProcess.options.timewindow.Value{1} , ...
                                                                                                 'remove_DC',      sProcess.options.remove_DC.Value, ...
-                                                                                                'baselinewindow', sProcess.options.baselinewindow.Value{1}, ...
-                                                                                                'overwrite',      0);
+                                                                                                'baselinewindow', sProcess.options.baselinewindow.Value{1} );
 
                 for iFile = 1:length(sInputs)
                     OutputFile  =     bst_process('CallProcess', 'process_windows_average_time', {sInputs(iFile).FileName},    [], ...
@@ -119,8 +110,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                                                                                     'timewindow',     sProcess.options.timewindow.Value{1} , ...
                                                                                     'remove_DC',      sProcess.options.remove_DC.Value, ...
                                                                                     'baselinewindow', sProcess.options.baselinewindow.Value{1}, ...
-                                                                                    'new_dataFIle', new_dataFIle.FileName, ...
-                                                                                    'overwrite',      0);
+                                                                                    'new_dataFIle', new_dataFIle.FileName );
 
                     OutputFiles{end+1} = OutputFile.FileName;
                 end
@@ -133,6 +123,10 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
         return;
     end
 
+
+    % Apply the average on one specific file. 
+
+    OutputFiles  = {};
     if strcmp(sInputs.FileType, 'data')     
         sDataIn = in_bst_data(sInputs.FileName );
 
@@ -159,6 +153,13 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
 
         sInputIn = struct('A', sDataIn.ImageGridAmp, 'TimeVector', sDataIn.Time,  'events', sData.Events); 
     end
+
+
+    options = struct('timewindow',      sProcess.options.timewindow.Value{1}, ...
+                 'remove_DC',       sProcess.options.remove_DC.Value,...
+                 'baselinewindow',  sProcess.options.baselinewindow.Value{1}, ...
+                 'Eventname',       sProcess.options.Eventname.Value);
+
 
     [time, value, nAvg] = windows_mean_based_on_event( sInputIn,  options  );
     

--- a/processes/process_windows_average/process_windows_average_time.m
+++ b/processes/process_windows_average/process_windows_average_time.m
@@ -214,8 +214,6 @@ end
 
 function [time, epochValues, Nepochs, includedTrials]=  windows_mean_based_on_event( sInput, options )
 %% we calculate the mean so that they are synchronised with events.  
-
-    [nChanel, ~] = size(sInput.A);
     
     try
         iEvent = find(strcmp({sInput.events.label}, options.Eventname));
@@ -239,7 +237,7 @@ function [time, epochValues, Nepochs, includedTrials]=  windows_mean_based_on_ev
     
     
     Nepochs     = size(Event.times,2);
-    epochValues = zeros(nChanel, Ntime, Nepochs);
+    epochValues = zeros(size(sInput.A), Ntime, Nepochs);
     isIncluded  = getTrialsInfo(Nepochs, options);
     
     for iEpoch=1:Nepochs

--- a/processes/process_windows_average/process_windows_average_time.m
+++ b/processes/process_windows_average/process_windows_average_time.m
@@ -73,7 +73,7 @@ end
 
 %% ===== RUN =====
 function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
-     
+     OutputFiles= {};
     if length(sInputs) > 1
         if strcmp(sInputs(1).FileType, 'data') 
 

--- a/processes/process_windows_average/process_windows_average_time.m
+++ b/processes/process_windows_average/process_windows_average_time.m
@@ -216,11 +216,17 @@ function [time, epochValues, Nepochs, includedTrials]=  windows_mean_based_on_ev
 %% we calculate the mean so that they are synchronised with events.  
 
     [nChanel, ~] = size(sInput.A);
+    
+    try
+        iEvent = find(strcmp({sInput.events.label}, options.Eventname));
+    catch
+        error('No event in the file');
+    end
 
-    iEvent = find(strcmp({sInput.events.label},options.Eventname));
     if isempty(iEvent) ||  isempty(sInput.events(iEvent).times )
         epochValues = [];
-        time  = [];
+        time  = []; includedTrials = [];
+        Nepochs  = 0;
         return; 
     end
     

--- a/processes/process_windows_average/process_windows_average_time.m
+++ b/processes/process_windows_average/process_windows_average_time.m
@@ -175,7 +175,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
     
 
 
-    [time, value, nAvg] = windows_mean_based_on_event( sInputIn,  options  );
+    [time, value, nAvg, includedTrials] = windows_mean_based_on_event( sInputIn,  options  );
     
     if isempty(time)
         bst_report('Error',   sProcess, sInputIn, 'Event not found');
@@ -188,7 +188,8 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
     sDataOut.Comment = [sDataOut.Comment sprintf(' | Avg: %s (%d) [%d,%ds] ',options.Eventname, ...
                                                                              nAvg, ...
                                                                              options.timewindow(1), options.timewindow(2))];
-
+    
+    sDataOut = bst_history('add',sDataOut, 'Compute', sprintf('Averaging trials:  %s', num2str(includedTrials)));
 
     if strcmp(sInputs.FileType, 'data') 
         sDataOut.F      = value;
@@ -207,7 +208,7 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                                                                         
 end
 
-function [time, epochValues, Nepochs]=  windows_mean_based_on_event( sInput, options )
+function [time, epochValues, Nepochs, includedTrials]=  windows_mean_based_on_event( sInput, options )
 %% we calculate the mean so that they are synchronised with events.  
 
     [nChanel, ~] = size(sInput.A);
@@ -250,7 +251,7 @@ function [time, epochValues, Nepochs]=  windows_mean_based_on_event( sInput, opt
     
     epochValues     = mean(epochValues(:, :, isIncluded) , 3);
     Nepochs         = sum(isIncluded);
-
+    includedTrials  = find(isIncluded);
 end
 
 

--- a/processes/process_windows_average/process_windows_average_time.m
+++ b/processes/process_windows_average/process_windows_average_time.m
@@ -237,7 +237,7 @@ function [time, epochValues, Nepochs, includedTrials]=  windows_mean_based_on_ev
     
     
     Nepochs     = size(Event.times,2);
-    epochValues = zeros(size(sInput.A), Ntime, Nepochs);
+    epochValues = zeros(size(sInput.A, 1), Ntime, Nepochs);
     isIncluded  = getTrialsInfo(Nepochs, options);
     
     for iEpoch=1:Nepochs


### PR DESCRIPTION
**Context**

The objective of the process is to do trial average for data on the cortical surface (since we cannot do the usual 'import in database > Average' for results on the cortex)

**Objective**

This PR is here for four things: 

- Correct a bug in the window generation
- Allow to select trials (reject bad trials)
- For the source, also compute the average on the datafile, so the source map can be associated with a new datafile. ( i really dont like maps being alone in the database) 
- Add more function than just the average, notably computing std, or std error 

**Results**

The final window looks like this : 

<img width="437" height="534" alt="image" src="https://github.com/user-attachments/assets/1d5902d2-0020-4387-8fcd-56998a8c6576" />


For example, inputting all those maps: 

![image](https://github.com/user-attachments/assets/3ef36745-3df3-427e-bbb6-c9d3404dfefc)


will generate: 


![image](https://github.com/user-attachments/assets/03096e0e-a0f4-47a4-b2db-41e4649d59ba)


**Known issue**

The only issue is, if you then press the 'reload last pipeline', then all the calls to the process appear instead of only one: 


![image](https://github.com/user-attachments/assets/1ccc5aa4-f461-4991-a22a-1a93234ba50d)


**Future objective**

- It would be nice to keep the events as we do when we do the average after importing into the database.
- Maybe we could integrate this process directly into Brainstorm as it's starting to be quite robust. 
